### PR TITLE
perf: make arena 10% smaller; store 1 offset + some deltas

### DIFF
--- a/src/arena.ts
+++ b/src/arena.ts
@@ -1,6 +1,6 @@
 // CSS Data Arena - Single contiguous ArrayBuffer for all AST nodes
 //
-// Each node occupies 44 bytes with the following layout:
+// Each node occupies 40 bytes with the following layout:
 // Offset | Size | Field
 // -------|------|-------------
 //   0    |  1   | type
@@ -9,18 +9,18 @@
 //   4    |  4   | startOffset
 //   8    |  2   | length
 //  10    |  2   | (padding)
-//  12    |  4   | contentStart (property name / at-rule name)
-//  16    |  2   | contentLength
-//  18    |  2   | (padding)
+//  12    |  2   | contentStartDelta (offset from startOffset, property name / at-rule name)
+//  14    |  2   | contentLength
+//  16    |  2   | valueStartDelta (offset from startOffset, declaration value / at-rule prelude)
+//  18    |  2   | valueLength
 //  20    |  4   | firstChild
 //  24    |  4   | lastChild
 //  28    |  4   | nextSibling
 //  32    |  4   | startLine
-//  36    |  4   | valueStart (declaration value / at-rule prelude)
-//  40    |  2   | valueLength
-//  42    |  2   | startColumn
+//  36    |  2   | startColumn
+//  38    |  2   | (padding)
 
-let BYTES_PER_NODE = 44
+let BYTES_PER_NODE = 40
 
 // Node type constants
 export const NODE_STYLESHEET = 1
@@ -160,14 +160,16 @@ export class CSSDataArena {
 		return this.view.getUint16(this.node_offset(node_index) + 8, true)
 	}
 
-	// Read content start offset
+	// Read content start offset (stored as delta from startOffset)
 	get_content_start(node_index: number): number {
-		return this.view.getUint32(this.node_offset(node_index) + 12, true)
+		const startOffset = this.get_start_offset(node_index)
+		const delta = this.view.getUint16(this.node_offset(node_index) + 12, true)
+		return startOffset + delta
 	}
 
 	// Read content length
 	get_content_length(node_index: number): number {
-		return this.view.getUint16(this.node_offset(node_index) + 16, true)
+		return this.view.getUint16(this.node_offset(node_index) + 14, true)
 	}
 
 	// Read attribute operator (for NODE_SELECTOR_ATTRIBUTE)
@@ -202,17 +204,19 @@ export class CSSDataArena {
 
 	// Read start column
 	get_start_column(node_index: number): number {
-		return this.view.getUint16(this.node_offset(node_index) + 42, true)
+		return this.view.getUint16(this.node_offset(node_index) + 36, true)
 	}
 
-	// Read value start offset (declaration value / at-rule prelude)
+	// Read value start offset (stored as delta from startOffset, declaration value / at-rule prelude)
 	get_value_start(node_index: number): number {
-		return this.view.getUint32(this.node_offset(node_index) + 36, true)
+		const startOffset = this.get_start_offset(node_index)
+		const delta = this.view.getUint16(this.node_offset(node_index) + 16, true)
+		return startOffset + delta
 	}
 
 	// Read value length
 	get_value_length(node_index: number): number {
-		return this.view.getUint16(this.node_offset(node_index) + 40, true)
+		return this.view.getUint16(this.node_offset(node_index) + 18, true)
 	}
 
 	// --- Write Methods ---
@@ -237,14 +241,16 @@ export class CSSDataArena {
 		this.view.setUint16(this.node_offset(node_index) + 8, length, true)
 	}
 
-	// Write content start offset
+	// Write content start offset (stored as delta from startOffset)
 	set_content_start(node_index: number, offset: number): void {
-		this.view.setUint32(this.node_offset(node_index) + 12, offset, true)
+		const startOffset = this.get_start_offset(node_index)
+		const delta = offset - startOffset
+		this.view.setUint16(this.node_offset(node_index) + 12, delta, true)
 	}
 
 	// Write content length
 	set_content_length(node_index: number, length: number): void {
-		this.view.setUint16(this.node_offset(node_index) + 16, length, true)
+		this.view.setUint16(this.node_offset(node_index) + 14, length, true)
 	}
 
 	// Write attribute operator (for NODE_SELECTOR_ATTRIBUTE)
@@ -279,17 +285,19 @@ export class CSSDataArena {
 
 	// Write start column
 	set_start_column(node_index: number, column: number): void {
-		this.view.setUint16(this.node_offset(node_index) + 42, column, true)
+		this.view.setUint16(this.node_offset(node_index) + 36, column, true)
 	}
 
-	// Write value start offset (declaration value / at-rule prelude)
+	// Write value start offset (stored as delta from startOffset, declaration value / at-rule prelude)
 	set_value_start(node_index: number, offset: number): void {
-		this.view.setUint32(this.node_offset(node_index) + 36, offset, true)
+		const startOffset = this.get_start_offset(node_index)
+		const delta = offset - startOffset
+		this.view.setUint16(this.node_offset(node_index) + 16, delta, true)
 	}
 
 	// Write value length
 	set_value_length(node_index: number, length: number): void {
-		this.view.setUint16(this.node_offset(node_index) + 40, length, true)
+		this.view.setUint16(this.node_offset(node_index) + 18, length, true)
 	}
 
 	// --- Node Creation ---


### PR DESCRIPTION
- [x] Measure before/after to see if it's actually faster
- [x] Measure before/after to see if it actually uses less memory

Performance remains the same but uses ~7% less memory while doing so.