### PR TITLE
breaking: add structured prelude property to AT_RULE and STYLE_RULE

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -184,6 +184,17 @@ describe('CSSNode', () => {
 			expect(hasPrelude).toBe(true)
 		})
 
+		test('should return true for style rules with selectors', () => {
+			const source = 'body { color: red; }'
+			const root = parse(source)
+			const rule = root.first_child!
+
+			expect(rule.type).toBe(STYLE_RULE)
+			expect(rule.has_prelude).toBe(true)
+			expect(rule.prelude).not.toBeNull()
+			expect(rule.prelude?.type_name).toBe('SelectorList')
+		})
+
 		test('should work for other node types that use value field', () => {
 			const source = 'body { color: red; }'
 			const root = parse(source, { parse_values: false })
@@ -193,12 +204,9 @@ describe('CSSNode', () => {
 			const declaration = block.first_child!
 
 			// Rules and selectors don't use value field
-			expect(rule.has_prelude).toBe(false)
-			expect(selector.has_prelude).toBe(false)
+			expect(rule.has_prelude).toBe(true) // has selector
 
-			// Declarations use value field for their value (same arena fields as prelude)
-			// So has_prelude returns true for declarations with values
-			expect(declaration.has_prelude).toBe(true)
+			expect(declaration.has_prelude).toBe(false)
 			expect(declaration.value).toBe('red')
 		})
 	})


### PR DESCRIPTION
breaking: add structured prelude property to AT_RULE and STYLE_RULE

  BREAKING CHANGES:

  1. AT_RULE.prelude now returns CSSNode|null instead of string
     - Returns AT_RULE_PRELUDE wrapper node containing structured children
     - Access text with .prelude?.text instead of .prelude
     - Raw string still available via .value
     - Returns null for at-rules without structured parsing (@charset, @namespace)

  2. STYLE_RULE.prelude now returns the selector list (CSSNode|null)
     - Returns first child (SELECTOR_LIST node)
     - Access selector text with .prelude?.text
     - Enables walking/traversing selector structure

  Changes:
  - Added AT_RULE_PRELUDE (40) node type for wrapping at-rule prelude children
  - Updated prelude getter to support AT_RULE and STYLE_RULE
  - Updated has_prelude getter to support AT_RULE, STYLE_RULE, and DECLARATION
  - Parser now wraps parsed prelude nodes in AT_RULE_PRELUDE wrapper
  - Removed backwards compatibility code from clone()
  - Updated all tests to use .prelude?.text instead of .prelude
  - Updated CLAUDE.md documentation

  Aligns with CSSTree API for better interoperability.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>