### PR TITLE
fix: always create an atrule prelude node if the atrule has a prelude

### DIFF
--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -79,6 +79,8 @@ export class AtRulePreludeParser {
 			return this.parse_identifier()
 		} else if (str_equals('import', at_rule_name)) {
 			return this.parse_import_prelude()
+		} else if (str_equals('charset', at_rule_name)) {
+			return this.parse_charset_prelude()
 		}
 		// For now, @namespace and other at-rules are not parsed
 
@@ -464,6 +466,21 @@ export class AtRulePreludeParser {
 		let ident = this.create_node(IDENTIFIER, this.lexer.token_start, this.lexer.token_end)
 
 		return [ident]
+	}
+
+	// Parse @charset prelude: "UTF-8"
+	private parse_charset_prelude(): number[] {
+		this.skip_whitespace()
+		if (this.lexer.pos >= this.prelude_end) return []
+
+		this.next_token()
+
+		if (this.lexer.token_type !== TOKEN_STRING) return []
+
+		// Create string node
+		let str = this.create_node(STRING, this.lexer.token_start, this.lexer.token_end)
+
+		return [str]
 	}
 
 	// Parse @import prelude: url() [layer] [supports()] [media-query-list]

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1082,9 +1082,9 @@ describe('Core Nodes', () => {
 
 					let atrule = root.first_child!
 					expect(atrule.name).toBe('charset')
-					// @charset doesn't have structured prelude parsing, use .value
 					expect(atrule.value).toBe('"UTF-8"')
-					expect(atrule.prelude).toBeNull()
+					expect(atrule.prelude).not.toBeNull()
+					expect(atrule.prelude?.text).toBe('"UTF-8"')
 				})
 
 				test('namespace prelude', () => {
@@ -1093,9 +1093,22 @@ describe('Core Nodes', () => {
 
 					let atrule = root.first_child!
 					expect(atrule.name).toBe('namespace')
-					// @namespace doesn't have structured prelude parsing, use .value
 					expect(atrule.value).toBe('svg url(http://www.w3.org/2000/svg)')
-					expect(atrule.prelude).toBeNull()
+					// @namespace doesn't have structured prelude parsing, but prelude wrapper exists
+					expect(atrule.prelude).not.toBeNull()
+					expect(atrule.prelude?.text).toBe('svg url(http://www.w3.org/2000/svg)')
+				})
+
+				test('unknown at-rule has prelude with accessible text', () => {
+					let source = '@imaginary-atrule prelude-stuff;'
+					let root = parse(source)
+
+					let atrule = root.first_child!
+					expect(atrule.name).toBe('imaginary-atrule')
+					expect(atrule.value).toBe('prelude-stuff')
+					// Unknown at-rules don't have structured prelude parsing, but prelude wrapper exists
+					expect(atrule.prelude).not.toBeNull()
+					expect(atrule.prelude?.text).toBe('prelude-stuff')
 				})
 
 				test('value string matches prelude text for at-rules', () => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -364,13 +364,13 @@ export class Parser {
 			this.arena.set_value_start_delta(at_rule, trimmed[0] - at_rule_start)
 			this.arena.set_value_length(at_rule, trimmed[1] - trimmed[0])
 
-			// Parse prelude if enabled
+			// Create AT_RULE_PRELUDE wrapper if prelude parsing is enabled
 			if (this.prelude_parser) {
-				let prelude_nodes = this.prelude_parser.parse_prelude(at_rule_name, trimmed[0], trimmed[1], at_rule_line, at_rule_column)
+				prelude_wrapper = this.arena.create_node(AT_RULE_PRELUDE, trimmed[0], trimmed[1] - trimmed[0], at_rule_line, at_rule_column)
 
-				// Wrap prelude nodes in an AT_RULE_PRELUDE wrapper
+				// Parse prelude and add structured nodes as children
+				let prelude_nodes = this.prelude_parser.parse_prelude(at_rule_name, trimmed[0], trimmed[1], at_rule_line, at_rule_column)
 				if (prelude_nodes.length > 0) {
-					prelude_wrapper = this.arena.create_node(AT_RULE_PRELUDE, trimmed[0], trimmed[1] - trimmed[0], at_rule_line, at_rule_column)
 					this.arena.append_children(prelude_wrapper, prelude_nodes)
 				}
 			}


### PR DESCRIPTION
Changes:

  1. src/parse-atrule-prelude.ts:82-84, 471-484: Added @charset prelude parser that returns a STRING node
  2. src/parse.ts:367-376: Always create AT_RULE_PRELUDE wrapper when prelude parsing is enabled, even for at-rules without structured parsing
  3. src/parse.test.ts:1085-1087, 1096-1099: Updated @charset and @namespace tests to expect preludes
  4. src/parse.test.ts:1102-1112: Added test for @imaginary-atrule proving unknown at-rules have accessible .prelude.text

  All 1079 tests pass. Now you can access .prelude.text for any at-rule with a prelude, regardless of whether it has structured parsing support.