### PR TITLE
fix: parse vendor prefixed atrules correctly

### DIFF
--- a/src/parse-atrule-prelude.test.ts
+++ b/src/parse-atrule-prelude.test.ts
@@ -814,6 +814,82 @@ describe('At-Rule Prelude Nodes', () => {
 			})
 		})
 
+		describe('vendor-prefixed at-rules', () => {
+			it('should parse @-webkit-keyframes same as @keyframes', () => {
+				const css = '@-webkit-keyframes slidein { }'
+				const ast = parse(css)
+				const atRule = ast.first_child!
+
+				expect(atRule?.type).toBe(AT_RULE)
+				expect(atRule?.name).toBe('-webkit-keyframes')
+				expect(atRule?.is_vendor_prefixed).toBe(true)
+
+				// Should have identifier prelude like @keyframes
+				const children = atRule.prelude?.children.filter((c) => c.type !== BLOCK) || []
+				expect(children.length).toBe(1)
+				expect(children[0].type).toBe(IDENTIFIER)
+				expect(children[0].text).toBe('slidein')
+			})
+
+			it('should parse @-moz-keyframes same as @keyframes', () => {
+				const css = '@-moz-keyframes fadein { }'
+				const ast = parse(css)
+				const atRule = ast.first_child!
+
+				expect(atRule?.type).toBe(AT_RULE)
+				expect(atRule?.name).toBe('-moz-keyframes')
+				expect(atRule?.is_vendor_prefixed).toBe(true)
+
+				const children = atRule.prelude?.children.filter((c) => c.type !== BLOCK) || []
+				expect(children.length).toBe(1)
+				expect(children[0].type).toBe(IDENTIFIER)
+				expect(children[0].text).toBe('fadein')
+			})
+
+			it('should parse @-o-keyframes same as @keyframes', () => {
+				const css = '@-o-keyframes rotate { }'
+				const ast = parse(css)
+				const atRule = ast.first_child!
+
+				expect(atRule?.type).toBe(AT_RULE)
+				expect(atRule?.name).toBe('-o-keyframes')
+				expect(atRule?.is_vendor_prefixed).toBe(true)
+
+				const children = atRule.prelude?.children.filter((c) => c.type !== BLOCK) || []
+				expect(children.length).toBe(1)
+				expect(children[0].type).toBe(IDENTIFIER)
+				expect(children[0].text).toBe('rotate')
+			})
+
+			it('should parse @-webkit-supports same as @supports', () => {
+				const css = '@-webkit-supports (display: flex) { }'
+				const ast = parse(css)
+				const atRule = ast.first_child!
+
+				expect(atRule?.type).toBe(AT_RULE)
+				expect(atRule?.name).toBe('-webkit-supports')
+				expect(atRule?.is_vendor_prefixed).toBe(true)
+
+				const children = atRule.prelude?.children || []
+				expect(children.length).toBeGreaterThan(0)
+				expect(children[0].type).toBe(SUPPORTS_QUERY)
+			})
+
+			it('should parse @-moz-supports same as @supports', () => {
+				const css = '@-moz-supports (display: grid) { }'
+				const ast = parse(css)
+				const atRule = ast.first_child!
+
+				expect(atRule?.type).toBe(AT_RULE)
+				expect(atRule?.name).toBe('-moz-supports')
+				expect(atRule?.is_vendor_prefixed).toBe(true)
+
+				const children = atRule.prelude?.children || []
+				expect(children.length).toBeGreaterThan(0)
+				expect(children[0].type).toBe(SUPPORTS_QUERY)
+			})
+		})
+
 		describe('@font-face', () => {
 			it('should have no prelude children', () => {
 				const css = '@font-face { font-family: "MyFont"; }'

--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -32,7 +32,7 @@ import {
 	TOKEN_DIMENSION,
 	type TokenType,
 } from './token-types'
-import { str_equals, is_whitespace, CHAR_COLON, CHAR_LESS_THAN, CHAR_GREATER_THAN, CHAR_EQUALS } from './string-utils'
+import { str_equals, is_whitespace, strip_vendor_prefix, CHAR_COLON, CHAR_LESS_THAN, CHAR_GREATER_THAN, CHAR_EQUALS } from './string-utils'
 import { trim_boundaries, skip_whitespace_forward } from './parse-utils'
 import { CSSNode } from './css-node'
 
@@ -65,21 +65,24 @@ export class AtRulePreludeParser {
 
 	// Dispatch to appropriate parser based on at-rule type
 	private parse_prelude_dispatch(at_rule_name: string): number[] {
-		if (str_equals('media', at_rule_name)) {
+		// Strip vendor prefix to treat @-webkit-keyframes same as @keyframes
+		let normalized_name = strip_vendor_prefix(at_rule_name)
+
+		if (str_equals('media', normalized_name)) {
 			return this.parse_media_query_list()
-		} else if (str_equals('container', at_rule_name)) {
+		} else if (str_equals('container', normalized_name)) {
 			return this.parse_container_query()
-		} else if (str_equals('supports', at_rule_name)) {
+		} else if (str_equals('supports', normalized_name)) {
 			return this.parse_supports_query()
-		} else if (str_equals('layer', at_rule_name)) {
+		} else if (str_equals('layer', normalized_name)) {
 			return this.parse_layer_names()
-		} else if (str_equals('keyframes', at_rule_name)) {
+		} else if (str_equals('keyframes', normalized_name)) {
 			return this.parse_identifier()
-		} else if (str_equals('property', at_rule_name)) {
+		} else if (str_equals('property', normalized_name)) {
 			return this.parse_identifier()
-		} else if (str_equals('import', at_rule_name)) {
+		} else if (str_equals('import', normalized_name)) {
 			return this.parse_import_prelude()
-		} else if (str_equals('charset', at_rule_name)) {
+		} else if (str_equals('charset', normalized_name)) {
 			return this.parse_charset_prelude()
 		}
 		// For now, @namespace and other at-rules are not parsed

--- a/src/string-utils.ts
+++ b/src/string-utils.ts
@@ -219,3 +219,33 @@ export function is_custom(str: string): boolean {
 	if (str.length < 3) return false
 	return str.charCodeAt(0) === CHAR_MINUS_HYPHEN && str.charCodeAt(1) === CHAR_MINUS_HYPHEN
 }
+
+/**
+ * Strip vendor prefix from a string
+ *
+ * @param str - The string to strip vendor prefix from
+ * @returns The string without vendor prefix, or original string if no prefix found
+ *
+ * Examples:
+ * - `-webkit-keyframes` → `keyframes`
+ * - `-moz-appearance` → `appearance`
+ * - `-ms-filter` → `filter`
+ * - `-o-border-image` → `border-image`
+ * - `keyframes` → `keyframes` (no change)
+ * - `--custom-property` → `--custom-property` (custom property, not vendor prefix)
+ */
+export function strip_vendor_prefix(str: string): string {
+	if (!is_vendor_prefixed(str)) {
+		return str
+	}
+
+	// Find the second hyphen (after the vendor name)
+	for (let i = 2; i < str.length; i++) {
+		if (str.charCodeAt(i) === CHAR_MINUS_HYPHEN) {
+			return str.substring(i + 1)
+		}
+	}
+
+	// Should never reach here if is_vendor_prefixed returned true
+	return str
+}


### PR DESCRIPTION
Changes:
  1. Added `strip_vendor_prefix()` function in src/string-utils.ts:237
  2. Updated `parse_prelude_dispatch()` in src/parse-atrule-prelude.ts:67 to normalize vendor-prefixed at-rule names before matching
  3. Added comprehensive tests in src/parse-atrule-prelude.test.ts:817

  Result:
  - `@-webkit-keyframes`, `@-moz-keyframes`, `@-o-keyframes` now parse identifiers (like `@keyframes`)
  - `@-webkit-supports`, `@-moz-supports` now parse support queries (like `@supports`)
  - All vendor-prefixed variants are treated identically to their unprefixed counterparts

  All 1091 tests pass ✓