### PR TITLE
breaking: replace `skip_comments` option with `on_comment`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export { type ParserOptions } from './parse'
 
 // Types
 export { CSSNode, type CSSNodeType, TYPE_NAMES, type CloneOptions, type PlainCSSNode } from './css-node'
-export type { LexerPosition } from './tokenize'
+export type { LexerPosition, CommentInfo } from './tokenize'
 
 export {
 	ATTR_OPERATOR_NONE,

--- a/src/parse-anplusb.ts
+++ b/src/parse-anplusb.ts
@@ -21,7 +21,7 @@ export class ANplusBParser {
 	constructor(arena: CSSDataArena, source: string) {
 		this.arena = arena
 		this.source = source
-		this.lexer = new Lexer(source, true) // skip comments
+		this.lexer = new Lexer(source)
 		this.expr_end = 0
 	}
 

--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -46,8 +46,8 @@ export class AtRulePreludeParser {
 	constructor(arena: CSSDataArena, source: string) {
 		this.arena = arena
 		this.source = source
-		// Create a lexer instance for prelude parsing (don't skip comments)
-		this.lexer = new Lexer(source, false)
+		// Create a lexer instance for prelude parsing
+		this.lexer = new Lexer(source)
 		this.prelude_end = 0
 	}
 

--- a/src/parse-declaration.ts
+++ b/src/parse-declaration.ts
@@ -38,7 +38,7 @@ export class DeclarationParser {
 	// Parse a declaration range into a declaration node (standalone use)
 	parse_declaration(start: number, end: number, line: number = 1, column: number = 1): number | null {
 		// Create a fresh lexer instance for standalone parsing
-		const lexer = new Lexer(this.source, false)
+		const lexer = new Lexer(this.source)
 		lexer.pos = start
 		lexer.line = line
 		lexer.column = column

--- a/src/parse-value.ts
+++ b/src/parse-value.ts
@@ -28,8 +28,8 @@ export class ValueParser {
 	constructor(arena: CSSDataArena, source: string) {
 		this.arena = arena
 		this.source = source
-		// Create a lexer instance for value parsing (don't skip comments in values)
-		this.lexer = new Lexer(source, false)
+		// Create a lexer instance for value parsing
+		this.lexer = new Lexer(source)
 		this.value_end = 0
 	}
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 // CSS Parser - Builds AST using the arena
-import { Lexer } from './tokenize'
+import { Lexer, type CommentInfo } from './tokenize'
 import {
 	CSSDataArena,
 	STYLESHEET,
@@ -35,10 +35,10 @@ import { trim_boundaries } from './parse-utils'
 import { CHAR_PERIOD, CHAR_GREATER_THAN, CHAR_PLUS, CHAR_TILDE, CHAR_AMPERSAND } from './string-utils'
 
 export interface ParserOptions {
-	skip_comments?: boolean
 	parse_values?: boolean
 	parse_selectors?: boolean
 	parse_atrule_preludes?: boolean
+	on_comment?: (info: CommentInfo) => void
 }
 
 // Static at-rule lookup sets for fast classification
@@ -60,15 +60,13 @@ export class Parser {
 	constructor(source: string, options?: ParserOptions) {
 		this.source = source
 
-		// Support legacy boolean parameter for backwards compatibility
 		let opts: ParserOptions = options || {}
 
-		let skip_comments = opts.skip_comments ?? true
 		this.parse_values_enabled = opts.parse_values ?? true
 		this.parse_selectors_enabled = opts.parse_selectors ?? true
 		this.parse_atrule_preludes_enabled = opts.parse_atrule_preludes ?? true
 
-		this.lexer = new Lexer(source, skip_comments)
+		this.lexer = new Lexer(source, opts.on_comment)
 		// Calculate optimal capacity based on source size
 		let capacity = CSSDataArena.capacity_for_source(source.length)
 		this.arena = new CSSDataArena(capacity)


### PR DESCRIPTION
Replaces `skip_comments` with `on_comment` which behaves very much like CSSTree's `onComment` except that it contains more information.

```
The `CommentInfo` object passed to `on_comment` contains:
  - `start: number` - Starting offset in source (0-based)
  - `end: number` - Ending offset in source (0-based)
  - `length: number` - Length of the comment
  - `line: number` - Starting line number (1-based)
  - `column: number` - Starting column number (1-based)
```

Another breaking change is that comments are not created as tokens anymore. The whole token stream only contains non-comment tokens which saves time during parsing.