### PR TITLE
perf: optimize advance() with lazy line/column tracking

### DIFF
--- a/src/parse-anplusb.ts
+++ b/src/parse-anplusb.ts
@@ -30,8 +30,7 @@ export class ANplusBParser {
 	 */
 	parse_anplusb(start: number, end: number, line: number = 1): number | null {
 		this.expr_end = end
-		this.lexer.pos = start
-		this.lexer.line = line
+		this.lexer.seek(start, line)
 
 		let b: string | null = null
 		let a_start = start

--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -56,9 +56,7 @@ export class AtRulePreludeParser {
 		this.prelude_end = end
 
 		// Position lexer at prelude start
-		this.lexer.pos = start
-		this.lexer.line = line
-		this.lexer.column = column
+		this.lexer.seek(start, line, column)
 
 		return this.parse_prelude_dispatch(at_rule_name)
 	}
@@ -745,9 +743,7 @@ export class AtRulePreludeParser {
 	private parse_feature_value(start: number, end: number): number[] {
 		// Use a temporary lexer for this range to avoid corrupting main lexer position state
 		let temp_lexer = new Lexer(this.source)
-		temp_lexer.pos = start
-		temp_lexer.line = this.lexer.line
-		temp_lexer.column = this.lexer.column
+		temp_lexer.seek(start, this.lexer.line, this.lexer.column)
 
 		let nodes: number[] = []
 		let saved_lexer = this.lexer

--- a/src/parse-declaration.ts
+++ b/src/parse-declaration.ts
@@ -40,9 +40,7 @@ export class DeclarationParser {
 	parse_declaration(start: number, end: number, line: number = 1, column: number = 1): number | null {
 		// Create a fresh lexer instance for standalone parsing
 		const lexer = new Lexer(this.source)
-		lexer.pos = start
-		lexer.line = line
-		lexer.column = column
+		lexer.seek(start, line, column)
 		lexer.next_token_fast(true) // skip whitespace like Parser does
 
 		return this.parse_declaration_with_lexer(lexer, end)

--- a/src/parse-selector.ts
+++ b/src/parse-selector.ts
@@ -89,9 +89,7 @@ export class SelectorParser {
 		this.selector_end = end
 
 		// Position lexer at selector start
-		this.lexer.pos = start
-		this.lexer.line = line
-		this.lexer.column = column
+		this.lexer.seek(start, line, column)
 
 		// Parse selector list (comma-separated selectors)
 		// Returns NODE_SELECTOR_LIST directly (no wrapper)
@@ -827,9 +825,7 @@ export class SelectorParser {
 	private parse_lang_identifiers(start: number, end: number, parent_node: number): void {
 		// Use a temporary lexer for this range to avoid corrupting main lexer position state
 		let temp_lexer = new Lexer(this.source)
-		temp_lexer.pos = start
-		temp_lexer.line = this.lexer.line
-		temp_lexer.column = this.lexer.column
+		temp_lexer.seek(start, this.lexer.line, this.lexer.column)
 
 		// Save current parser state
 		let saved_selector_end = this.selector_end

--- a/src/parse-value.ts
+++ b/src/parse-value.ts
@@ -40,9 +40,7 @@ export class ValueParser {
 		this.value_end = end
 
 		// Position lexer at value start with provided line/column
-		this.lexer.pos = start
-		this.lexer.line = start_line
-		this.lexer.column = start_column
+		this.lexer.seek(start, start_line, start_column)
 
 		// Parse individual value tokens
 		let value_nodes = this.parse_value_tokens()


### PR DESCRIPTION
- Replace per-character column tracking with lazy computation via getter
- Inline newline check using char_types bitmask to avoid function call
- Add seek() method for encapsulated lexer repositioning
- Update all sub-parsers to use seek() instead of direct property writes

Column is now computed as `pos - _line_offset + 1` only when accessed, eliminating column++ on ~99% of characters (non-newlines).