### PR TITLE
perf: inline is_ident_char() in hot tokenizer loops via CHAR_IDENT bi…

### DIFF
--- a/src/char-types.ts
+++ b/src/char-types.ts
@@ -26,6 +26,7 @@ export let CHAR_DIGIT = 1 << 1 // 2
 export let CHAR_HEX = 1 << 2 // 4
 export let CHAR_WHITESPACE = 1 << 3 // 8
 export let CHAR_NEWLINE = 1 << 4 // 16
+export let CHAR_IDENT = 1 << 5 // 32
 
 // Lookup table for ASCII characters (0-127)
 export let char_types = new Uint8Array(128)
@@ -62,6 +63,16 @@ char_types[0x09] = CHAR_WHITESPACE // tab
 char_types[0x0a] = CHAR_NEWLINE // \n
 char_types[0x0d] = CHAR_NEWLINE // \r
 char_types[0x0c] = CHAR_NEWLINE // \f
+
+// Initialize ident characters: letters, digits, hyphen (-), underscore (_)
+// Derived from already-populated table so it stays consistent with CHAR_ALPHA/CHAR_DIGIT
+for (let i = 0; i < 128; i++) {
+	if (char_types[i] & (CHAR_ALPHA | CHAR_DIGIT)) {
+		char_types[i] |= CHAR_IDENT
+	}
+}
+char_types[0x2d] |= CHAR_IDENT // hyphen -
+char_types[0x5f] |= CHAR_IDENT // underscore _
 
 export function is_digit(ch: number): boolean {
 	return ch < 128 && (char_types[ch] & CHAR_DIGIT) !== 0


### PR DESCRIPTION
…tmask

Add CHAR_IDENT (1 << 5) to the lookup table and replace all 4 is_ident_char() callsites in tight loops with a direct bitmask check, eliminating the 3-function call chain (is_ident_char → is_ident_start → is_alpha) on every character scanned.

Benchmark results vs main:
- Tokenizer - Large CSS:      29,920 → 32,064 ops/sec  (+7.2%)
- Tokenizer - Bootstrap CSS:    356  →    401 ops/sec (+12.6%)
- Tokenizer - Tailwind CSS:      28  →     31 ops/sec (+10.7%)
- Parser - Large CSS:         18,801 → 19,908 ops/sec  (+5.9%)
- Parser - Bootstrap CSS:       231  →    244 ops/sec  (+5.6%)
- Parser - Tailwind CSS:         17  →     18 ops/sec  (+5.9%)
- Parse/walk - Bootstrap CSS:   204  →    215 ops/sec  (+5.4%)
- Parse/walk - Tailwind CSS:     15  →     16 ops/sec  (+6.7%)