### PR TITLE
Refactor lexer state management to use save/restore pattern

### DIFF
--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -877,13 +877,10 @@ export class AtRulePreludeParser {
 
 	// Helper: Parse feature value portion into typed nodes
 	private parse_feature_value(start: number, end: number): number[] {
-		// Use a temporary lexer for this range to avoid corrupting main lexer position state
-		let temp_lexer = new Lexer(this.source)
-		temp_lexer.seek(start, this.lexer.line, this.lexer.column)
+		const saved_position = this.lexer.save_position()
+		this.lexer.seek(start, this.lexer.line, this.lexer.column)
 
 		let nodes: number[] = []
-		let saved_lexer = this.lexer
-		this.lexer = temp_lexer
 
 		while (this.lexer.pos < end) {
 			this.lexer.next_token_fast(false)
@@ -904,7 +901,7 @@ export class AtRulePreludeParser {
 			if (node !== null) nodes.push(node)
 		}
 
-		this.lexer = saved_lexer
+		this.lexer.restore_position(saved_position)
 		return nodes
 	}
 

--- a/src/parse-selector.ts
+++ b/src/parse-selector.ts
@@ -71,13 +71,14 @@ export class SelectorParser {
 	private arena: CSSDataArena
 	private source: string
 	private selector_end: number
+	private anplusb_parser: ANplusBParser
 
 	constructor(arena: CSSDataArena, source: string) {
 		this.arena = arena
 		this.source = source
-		// Create a lexer instance for selector parsing
 		this.lexer = new Lexer(source)
 		this.selector_end = 0
+		this.anplusb_parser = new ANplusBParser(arena, source)
 	}
 
 	// Parse a selector range into selector nodes (standalone use)
@@ -858,14 +859,10 @@ export class SelectorParser {
 	// Parse :lang() content - comma-separated language identifiers
 	// Accepts both quoted strings: :lang("en", "fr") and unquoted: :lang(en, fr)
 	private parse_lang_identifiers(start: number, end: number, parent_node: number): void {
-		// Use a temporary lexer for this range to avoid corrupting main lexer position state
-		let temp_lexer = new Lexer(this.source)
-		temp_lexer.seek(start, this.lexer.line, this.lexer.column)
+		const saved_position = this.lexer.save_position()
+		this.lexer.seek(start, this.lexer.line, this.lexer.column)
 
-		// Save current parser state
 		let saved_selector_end = this.selector_end
-		let saved_lexer = this.lexer
-		this.lexer = temp_lexer
 		this.selector_end = end
 
 		let first_child: number | null = null
@@ -913,9 +910,8 @@ export class SelectorParser {
 			this.arena.set_first_child(parent_node, first_child)
 		}
 
-		// Restore parser state
 		this.selector_end = saved_selector_end
-		this.lexer = saved_lexer
+		this.lexer.restore_position(saved_position)
 	}
 
 	// Parse An+B expression for nth-* pseudo-classes
@@ -925,7 +921,7 @@ export class SelectorParser {
 		// e.g., "2n+1 of .active, .disabled"
 		let of_index = this.find_of_keyword(start, end)
 
-		let anplusb_parser = new ANplusBParser(this.arena, this.source)
+		let anplusb_parser = this.anplusb_parser
 
 		if (of_index === -1) {
 			// Just An+B, no "of" clause


### PR DESCRIPTION
## Summary

Eliminates per-call `Lexer` allocations in the hot paths of `SelectorParser` and `AtRulePreludeParser`:

- **`ANplusBParser` in `parse_nth_expression()`** — was allocating a new `ANplusBParser` (and therefore a new `Lexer`) for every `:nth-child()`, `:nth-of-type()`, etc. encountered. Promoted to a field on `SelectorParser`, initialized once in the constructor.
- **Temp `Lexer` in `parse_lang_identifiers()`** — replaced `new Lexer()` + reference swap with `lexer.save_position()` / `restore_position()`.
- **Temp `Lexer` in `parse_feature_value()`** — same save/restore replacement.

## Benchmark results

Tested against `main` (Bootstrap 273 KB, Tailwind 3.5 MB). ops/sec, higher is better.

| Task | `main` | this PR | Δ |
|---|---|---|---|
| Parser — Large CSS (3 KB) | 7 550 | 9 236 | **+22%** |
| Parser — Bootstrap CSS (274 KB) | 88 | 104 | **+18%** |
| Parser — Tailwind CSS (3.5 MB) | 6 | 7 | **+13%** |
| Parse/walk — Bootstrap CSS | 81 | 96 | **+18%** |
| Parse/walk — Tailwind CSS | 6 | 7 | **+14%** |

Tokenizer-only benchmarks are unchanged (expected — these changes only affect the selector and prelude parsers).

https://claude.ai/code/session_01CQeKNnXidD5EQVJY4xBMMp