### PR TITLE
Add dependency diff workflow for pull requests

### DIFF
--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,0 +1,73 @@
+name: Dependency Diff
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-base:
+    name: Pack base branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm run build
+      - run: pnpm pack --pack-destination ./base-packs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: base-packages
+          path: ./base-packs/*.tgz
+
+  build-pr:
+    name: Pack PR branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm run build
+      - run: pnpm pack --pack-destination ./source-packs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: source-packages
+          path: ./source-packs/*.tgz
+
+  diff-dependencies:
+    name: Diff dependencies
+    runs-on: ubuntu-latest
+    needs: [build-base, build-pr]
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: base-packages
+          path: ./base-packs
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-packages
+          path: ./source-packs
+      - uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc # v1.6.1
+        with:
+          base-packages: './base-packs/*.tgz'
+          source-packages: './source-packs/*.tgz'
+          pack-size-threshold: -1


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically generates a dependency diff report for pull requests, comparing the dependencies of the base branch against the PR branch.

## Key Changes
- Added `.github/workflows/dependency-diff.yml` workflow with three jobs:
  - **build-base**: Checks out the main branch, installs dependencies, builds the project, and packs it for comparison
  - **build-pr**: Checks out the PR branch, installs dependencies, builds the project, and packs it for comparison
  - **diff-dependencies**: Downloads both packed versions and generates a dependency diff report, posting results as a PR comment

## Implementation Details
- Uses pnpm for package management with frozen lockfile to ensure reproducible builds
- Node.js 22 is used for both base and PR builds
- The workflow runs on pull requests targeting the main branch
- Artifacts are uploaded and downloaded between jobs for efficient comparison
- Uses the `e18e/action-dependency-diff` action to generate the actual dependency diff
- Pack size threshold is set to -1 to report all changes regardless of size
- Includes appropriate permissions for reading contents and writing PR comments

https://claude.ai/code/session_016YoApD2Ax54MAE1m3G5RcL