### PR TITLE
Optimize parser by chaining nodes as siblings instead of arrays (up to 14% faster)

### DIFF
--- a/src/arena.ts
+++ b/src/arena.ts
@@ -369,6 +369,18 @@ export class CSSDataArena {
 		this.capacity = this.count
 	}
 
+	// Walk a sibling chain to find its last node. Used by parsers that build sibling chains
+	// incrementally (without an intermediate array) and need to append to the tail.
+	get_last_sibling(node_index: number): number {
+		let node = node_index
+		let next = this.get_next_sibling(node)
+		while (next !== 0) {
+			node = next
+			next = this.get_next_sibling(node)
+		}
+		return node
+	}
+
 	// Check if a node has any children
 	has_children(node_index: number): boolean {
 		return this.get_first_child(node_index) !== 0

--- a/src/parse-atrule-prelude.ts
+++ b/src/parse-atrule-prelude.ts
@@ -187,8 +187,11 @@ export class AtRulePreludeParser {
 			this.lexer.restore_position(saved_token_start)
 		}
 
-		// Parse components (media type, features, operators)
-		let components: number[] = []
+		// Parse components (media type, features, operators), chained as siblings without an
+		// intermediate array — most media queries have exactly one component (a single media
+		// type or a single feature), so this avoids an allocation for the common case.
+		let first_component = 0
+		let last_component = 0
 
 		while (this.lexer.pos < this.prelude_end) {
 			this.skip_whitespace()
@@ -200,12 +203,11 @@ export class AtRulePreludeParser {
 			this.next_token()
 
 			let token_type = this.lexer.token_type
+			let component: number | null = null
+
 			// Media feature: (min-width: 768px)
 			if (token_type === TOKEN_LEFT_PAREN) {
-				let feature = this.parse_media_feature()
-				if (feature !== null) {
-					components.push(feature)
-				}
+				component = this.parse_media_feature()
 			}
 			// Identifier: media type or operator (and, or, not)
 			else if (token_type === TOKEN_IDENT) {
@@ -213,30 +215,37 @@ export class AtRulePreludeParser {
 
 				if (this.is_and_or_not(text)) {
 					// Logical operator
-					let op = this.create_node(PRELUDE_OPERATOR, this.lexer.token_start, this.lexer.token_end)
-					components.push(op)
-				} else {
-					// Media type: screen, print, all
-					let media_type = this.create_node(
-						MEDIA_TYPE,
+					component = this.create_node(
+						PRELUDE_OPERATOR,
 						this.lexer.token_start,
 						this.lexer.token_end,
 					)
-					components.push(media_type)
+				} else {
+					// Media type: screen, print, all
+					component = this.create_node(MEDIA_TYPE, this.lexer.token_start, this.lexer.token_end)
 				}
 			} else {
 				// Unknown token, skip
 				break
 			}
+
+			if (component !== null) {
+				if (first_component === 0) {
+					first_component = component
+				} else {
+					this.arena.set_next_sibling(last_component, component)
+				}
+				last_component = component
+			}
 		}
 
-		if (components.length === 0) return null
+		if (first_component === 0) return null
 
 		// Create media query node
 		let query_node = this.create_node(MEDIA_QUERY, query_start, this.lexer.pos)
 
-		// Append components as children
-		this.arena.append_children(query_node, components)
+		// Link components as children
+		this.arena.set_first_child(query_node, first_component)
 
 		return query_node
 	}
@@ -320,9 +329,9 @@ export class AtRulePreludeParser {
 			// Parse value portion
 			let value_trimmed = trim_boundaries(this.source, colon_pos + 1, content_end)
 			if (value_trimmed) {
-				let value_nodes = this.parse_feature_value(value_trimmed[0], value_trimmed[1])
-				if (value_nodes.length > 0) {
-					this.arena.append_children(feature, value_nodes)
+				let value_first = this.parse_feature_value(value_trimmed[0], value_trimmed[1])
+				if (value_first !== 0) {
+					this.arena.set_first_child(feature, value_first)
 				}
 			}
 		}
@@ -332,11 +341,12 @@ export class AtRulePreludeParser {
 
 	// Parse container query: [name] and (min-width: 400px)
 	private parse_container_query(): number[] {
-		let nodes: number[] = []
 		let query_start = this.lexer.pos
 
-		// Parse components (identifiers, operators, features)
-		let components: number[] = []
+		// Parse components (identifiers, operators, features), chained as siblings without an
+		// intermediate array — most container queries have a single component.
+		let first_component = 0
+		let last_component = 0
 
 		while (this.lexer.pos < this.prelude_end) {
 			this.skip_whitespace()
@@ -345,12 +355,11 @@ export class AtRulePreludeParser {
 			this.next_token()
 
 			let token_type = this.lexer.token_type
+			let component: number | null = null
+
 			// Container feature: (min-width: 400px)
 			if (token_type === TOKEN_LEFT_PAREN) {
-				let feature = this.parse_media_feature() // Reuse media feature parser
-				if (feature !== null) {
-					components.push(feature)
-				}
+				component = this.parse_media_feature() // Reuse media feature parser
 			}
 			// Function: style(--custom: 1)
 			else if (token_type === TOKEN_FUNCTION) {
@@ -390,7 +399,7 @@ export class AtRulePreludeParser {
 				this.arena.set_value_start_delta(func_node, content_start - func_start)
 				this.arena.set_value_length(func_node, content_end - content_start)
 
-				components.push(func_node)
+				component = func_node
 			}
 			// Identifier: operator (and, or, not) or container name
 			else if (token_type === TOKEN_IDENT) {
@@ -398,26 +407,36 @@ export class AtRulePreludeParser {
 
 				if (this.is_and_or_not(text)) {
 					// Logical operator
-					let op = this.create_node(PRELUDE_OPERATOR, this.lexer.token_start, this.lexer.token_end)
-					components.push(op)
+					component = this.create_node(
+						PRELUDE_OPERATOR,
+						this.lexer.token_start,
+						this.lexer.token_end,
+					)
 				} else {
 					// Container name or other identifier
-					let name = this.create_node(IDENTIFIER, this.lexer.token_start, this.lexer.token_end)
-					components.push(name)
+					component = this.create_node(IDENTIFIER, this.lexer.token_start, this.lexer.token_end)
 				}
+			}
+
+			if (component !== null) {
+				if (first_component === 0) {
+					first_component = component
+				} else {
+					this.arena.set_next_sibling(last_component, component)
+				}
+				last_component = component
 			}
 		}
 
-		if (components.length === 0) return []
+		if (first_component === 0) return []
 
 		// Create container query node
 		let query_node = this.create_node(CONTAINER_QUERY, query_start, this.lexer.pos)
 
-		// Append components as children
-		this.arena.append_children(query_node, components)
+		// Link components as children
+		this.arena.set_first_child(query_node, first_component)
 
-		nodes.push(query_node)
-		return nodes
+		return [query_node]
 	}
 
 	// Parse supports query: (display: flex) and (gap: 1rem)
@@ -466,7 +485,7 @@ export class AtRulePreludeParser {
 						let colon_pos = this.find_colon_at_depth_zero(trimmed[0], trimmed[1])
 						if (colon_pos !== -1) {
 							let decl_child = this.create_supports_declaration(trimmed[0], trimmed[1], colon_pos)
-							this.arena.append_children(query, [decl_child])
+							this.arena.set_first_child(query, decl_child)
 						}
 					}
 
@@ -526,9 +545,9 @@ export class AtRulePreludeParser {
 		this.arena.set_content_length(decl, prop_trimmed[1] - prop_trimmed[0])
 
 		if (val_trimmed) {
-			let value_nodes = this.parse_feature_value(val_trimmed[0], val_trimmed[1])
+			let value_first = this.parse_feature_value(val_trimmed[0], val_trimmed[1])
 			let value_node: number
-			if (value_nodes.length === 0) {
+			if (value_first === 0) {
 				value_node = this.arena.create_node(
 					VALUE,
 					val_trimmed[0],
@@ -544,13 +563,13 @@ export class AtRulePreludeParser {
 					this.lexer.token_line,
 					this.lexer.token_column,
 				)
-				this.arena.append_children(value_node, value_nodes)
+				this.arena.set_first_child(value_node, value_first)
 			}
-			this.arena.append_children(decl, [value_node])
+			this.arena.set_first_child(decl, value_node)
 		}
 
 		let supports_decl = this.create_node(SUPPORTS_DECLARATION, content_start, content_end)
-		this.arena.append_children(supports_decl, [decl])
+		this.arena.set_first_child(supports_decl, decl)
 		return supports_decl
 	}
 
@@ -906,12 +925,15 @@ export class AtRulePreludeParser {
 		}
 	}
 
-	// Helper: Parse feature value portion into typed nodes
-	private parse_feature_value(start: number, end: number): number[] {
+	// Helper: Parse feature value portion into typed nodes, chained as siblings without an
+	// intermediate array. Returns the first node in the chain (0 if none) — the common case is
+	// a single value (e.g. `min-width: 768px`), so callers get that node directly.
+	private parse_feature_value(start: number, end: number): number {
 		const saved_position = this.lexer.save_position()
 		this.lexer.seek(start, this.lexer.line, this.lexer.column)
 
-		let nodes: number[] = []
+		let first_node = 0
+		let last_node = 0
 
 		while (this.lexer.pos < end) {
 			this.lexer.next_token_fast(false)
@@ -929,11 +951,18 @@ export class AtRulePreludeParser {
 
 			// Create node based on token type
 			let node = this.parse_value_token()
-			if (node !== null) nodes.push(node)
+			if (node !== null) {
+				if (first_node === 0) {
+					first_node = node
+				} else {
+					this.arena.set_next_sibling(last_node, node)
+				}
+				last_node = node
+			}
 		}
 
 		this.lexer.restore_position(saved_position)
-		return nodes
+		return first_node
 	}
 
 	// Parse @namespace prelude: [prefix] url("...") | "..."
@@ -1036,7 +1065,8 @@ export class AtRulePreludeParser {
 		content_end: number,
 	): number {
 		let range_node = this.create_node(FEATURE_RANGE, feature_start, feature_end)
-		let children: number[] = []
+		let first_child = 0
+		let last_child = 0
 		let feature_name_start = -1
 		let feature_name_end = -1
 
@@ -1054,7 +1084,12 @@ export class AtRulePreludeParser {
 				if (pos < content_end && this.source.charCodeAt(pos) === CHAR_EQUALS) pos++
 
 				let op = this.create_node(PRELUDE_OPERATOR, op_start, pos)
-				children.push(op)
+				if (first_child === 0) {
+					first_child = op
+				} else {
+					this.arena.set_next_sibling(last_child, op)
+				}
+				last_child = op
 			} else {
 				// Value or feature name
 				let saved = this.lexer.save_position()
@@ -1066,9 +1101,16 @@ export class AtRulePreludeParser {
 					feature_name_start = this.lexer.token_start
 					feature_name_end = this.lexer.token_end
 				} else {
-					// Value
-					let value_nodes = this.parse_feature_value(this.lexer.token_start, this.lexer.token_end)
-					children.push(...value_nodes)
+					// Value (may itself be a short chain, e.g. a single dimension node)
+					let value_first = this.parse_feature_value(this.lexer.token_start, this.lexer.token_end)
+					if (value_first !== 0) {
+						if (first_child === 0) {
+							first_child = value_first
+						} else {
+							this.arena.set_next_sibling(last_child, value_first)
+						}
+						last_child = this.arena.get_last_sibling(value_first)
+					}
 				}
 
 				pos = this.lexer.pos
@@ -1082,7 +1124,9 @@ export class AtRulePreludeParser {
 			this.arena.set_content_length(range_node, feature_name_end - feature_name_start)
 		}
 
-		this.arena.append_children(range_node, children)
+		if (first_child !== 0) {
+			this.arena.set_first_child(range_node, first_child)
+		}
 		return range_node
 	}
 }

--- a/src/parse-declaration.ts
+++ b/src/parse-declaration.ts
@@ -233,7 +233,7 @@ export class DeclarationParser {
 				)
 
 				// Link VALUE node as single child of the declaration
-				this.arena.append_children(declaration, [valueNode])
+				this.arena.set_first_child(declaration, valueNode)
 			} else {
 				// Create RAW node for unparsed value text
 				let rawNode = this.arena.create_node(
@@ -243,7 +243,7 @@ export class DeclarationParser {
 					value_start_line,
 					value_start_column,
 				)
-				this.arena.append_children(declaration, [rawNode])
+				this.arena.set_first_child(declaration, rawNode)
 			}
 		} else {
 			// Empty value - set zero-length value field so node.value returns "" instead of null
@@ -258,7 +258,7 @@ export class DeclarationParser {
 					value_start_line,
 					value_start_column,
 				)
-				this.arena.append_children(declaration, [valueNode])
+				this.arena.set_first_child(declaration, valueNode)
 			}
 		}
 

--- a/src/parse-selector.ts
+++ b/src/parse-selector.ts
@@ -102,7 +102,11 @@ export class SelectorParser {
 
 	// Parse comma-separated selectors
 	private parse_selector_list(allow_relative: boolean = true): number | null {
-		let selectors: number[] = []
+		// Chain selector wrappers as siblings without an intermediate array — most selector
+		// lists contain a single selector (no comma), so this avoids an allocation for the
+		// common case.
+		let first_selector = 0
+		let last_selector = 0
 		let list_start = this.lexer.pos
 		let list_line = this.lexer.line
 		let list_column = this.lexer.column
@@ -125,18 +129,15 @@ export class SelectorParser {
 				this.arena.set_content_start_delta(selector_wrapper, 0)
 				this.arena.set_content_length(selector_wrapper, this.lexer.pos - selector_start)
 
-				// Find the last component in the chain
-				let last_component = complex_selector
-				let next_sibling = this.arena.get_next_sibling(last_component)
-				while (next_sibling !== 0) {
-					last_component = next_sibling
-					next_sibling = this.arena.get_next_sibling(last_component)
-				}
-
 				// Set the complex selector chain as children
 				this.arena.set_first_child(selector_wrapper, complex_selector)
 
-				selectors.push(selector_wrapper)
+				if (first_selector === 0) {
+					first_selector = selector_wrapper
+				} else {
+					this.arena.set_next_sibling(last_selector, selector_wrapper)
+				}
+				last_selector = selector_wrapper
 			}
 
 			// Check for comma (selector separator)
@@ -158,7 +159,7 @@ export class SelectorParser {
 		}
 
 		// Always wrap in selector list node, even for single selectors
-		if (selectors.length > 0) {
+		if (first_selector !== 0) {
 			let list_node = this.arena.create_node(
 				SELECTOR_LIST,
 				list_start,
@@ -168,7 +169,7 @@ export class SelectorParser {
 			)
 
 			// Link selector wrapper nodes as children
-			this.arena.append_children(list_node, selectors)
+			this.arena.set_first_child(list_node, first_selector)
 
 			return list_node
 		}
@@ -180,7 +181,12 @@ export class SelectorParser {
 	// e.g., "div.class > p + span"
 	// Also supports CSS Nesting relaxed syntax: "> a", "~ span", etc.
 	private parse_complex_selector(allow_relative: boolean = true): number | null {
-		let components: number[] = []
+		// Chain components (compounds/combinators) as siblings without an intermediate array.
+		// Each compound selector may itself already be a chain of parts (e.g. `.foo.bar`), so
+		// `chain_tail` always points at the true end of the chain built so far, found via
+		// `arena.get_last_sibling` after appending a compound.
+		let first_component = 0
+		let chain_tail = 0
 
 		// Skip leading whitespace
 		this.skip_whitespace()
@@ -204,7 +210,8 @@ export class SelectorParser {
 						this.lexer.token_line,
 						this.lexer.token_column,
 					)
-					components.push(combinator)
+					first_component = combinator
+					chain_tail = combinator
 					this.skip_whitespace()
 					// Continue to parse the rest normally
 				} else {
@@ -223,12 +230,18 @@ export class SelectorParser {
 			if (compound === null) {
 				break
 			}
-			components.push(compound)
+			if (chain_tail === 0) {
+				first_component = compound
+			} else {
+				this.arena.set_next_sibling(chain_tail, compound)
+			}
+			chain_tail = this.arena.get_last_sibling(compound)
 
 			// After a compound selector, check if there's a combinator
 			let combinator = this.try_parse_combinator()
 			if (combinator !== null) {
-				components.push(combinator)
+				this.arena.set_next_sibling(chain_tail, combinator)
+				chain_tail = combinator
 				// Skip whitespace after combinator before next compound
 				this.skip_whitespace()
 				continue
@@ -254,27 +267,16 @@ export class SelectorParser {
 			break
 		}
 
-		if (components.length === 0) return null
-
-		// Chain components as siblings (need to find last node in each compound selector chain)
-		for (let i = 0; i < components.length - 1; i++) {
-			// Find the last node in the current component's chain
-			let last_node = components[i]
-			while (this.arena.get_next_sibling(last_node) !== 0) {
-				last_node = this.arena.get_next_sibling(last_node)
-			}
-			// Link the last node to the next component
-			this.arena.set_next_sibling(last_node, components[i + 1])
-		}
-
-		// Return first component (others are chained as siblings)
-		return components[0]
+		return first_component === 0 ? null : first_component
 	}
 
 	// Parse a compound selector (no combinators)
 	// e.g., "div.class#id[attr]:hover"
 	private parse_compound_selector(): number | null {
-		let parts: number[] = []
+		// Chain parts as siblings without an intermediate array — most compound selectors
+		// have exactly one part (e.g. a single class or type selector).
+		let first_part = 0
+		let last_part = 0
 
 		while (this.lexer.pos < this.selector_end) {
 			// Save lexer state before getting token
@@ -292,18 +294,15 @@ export class SelectorParser {
 				this.lexer.restore_position(saved)
 				break
 			}
-			parts.push(part)
+			if (first_part === 0) {
+				first_part = part
+			} else {
+				this.arena.set_next_sibling(last_part, part)
+			}
+			last_part = part
 		}
 
-		if (parts.length === 0) return null
-
-		// Chain parts as siblings
-		for (let i = 0; i < parts.length - 1; i++) {
-			this.arena.set_next_sibling(parts[i], parts[i + 1])
-		}
-
-		// Return first part (others are chained as siblings)
-		return parts[0]
+		return first_part === 0 ? null : first_part
 	}
 
 	// Parse a simple selector (single component)

--- a/src/parse-value.ts
+++ b/src/parse-value.ts
@@ -63,41 +63,12 @@ export class ValueParser {
 		// Position lexer at value start with provided line/column
 		this.lexer.seek(start, start_line, start_column)
 
-		// Parse individual value tokens
-		let value_nodes = this.parse_value_tokens()
+		// Parse individual value tokens, chaining them as siblings without an intermediate array.
+		// The common case is a single token (e.g. `color: red`), so this avoids allocating and
+		// pushing into an array for what is by far the most frequent shape of a declaration value.
+		let first_node = 0
+		let last_node = 0
 
-		// Wrap in VALUE node
-		if (value_nodes.length === 0) {
-			// Empty value - create VALUE node with no children
-			let value_node = this.arena.create_node(VALUE, start, 0, start_line, start_column)
-			return value_node
-		}
-
-		// Create VALUE wrapper node spanning all value tokens
-		let first_node_start = this.arena.get_start_offset(value_nodes[0])
-		let last_node_index = value_nodes.at(-1)!
-		let last_node_end =
-			this.arena.get_start_offset(last_node_index) + this.arena.get_length(last_node_index)
-
-		let value_node = this.arena.create_node(
-			VALUE,
-			first_node_start,
-			last_node_end - first_node_start,
-			start_line,
-			start_column,
-		)
-
-		// Link value tokens as children
-		this.arena.append_children(value_node, value_nodes)
-
-		return value_node
-	}
-
-	// Core token parsing logic
-	private parse_value_tokens(): number[] {
-		let nodes: number[] = []
-
-		// Parse all tokens in the value range
 		while (this.lexer.pos < this.value_end) {
 			// Get next token without skipping whitespace (whitespace matters in values)
 			this.lexer.next_token_fast(false)
@@ -116,11 +87,38 @@ export class ValueParser {
 			// Parse this token into a value node (token_type already cached in lexer.token_type)
 			let node = this.parse_value_node()
 			if (node !== null) {
-				nodes.push(node)
+				if (first_node === 0) {
+					first_node = node
+				} else {
+					this.arena.set_next_sibling(last_node, node)
+				}
+				last_node = node
 			}
 		}
 
-		return nodes
+		// Wrap in VALUE node
+		if (first_node === 0) {
+			// Empty value - create VALUE node with no children
+			let value_node = this.arena.create_node(VALUE, start, 0, start_line, start_column)
+			return value_node
+		}
+
+		// Create VALUE wrapper node spanning all value tokens
+		let first_node_start = this.arena.get_start_offset(first_node)
+		let last_node_end = this.arena.get_start_offset(last_node) + this.arena.get_length(last_node)
+
+		let value_node = this.arena.create_node(
+			VALUE,
+			first_node_start,
+			last_node_end - first_node_start,
+			start_line,
+			start_column,
+		)
+
+		// Link value tokens as children
+		this.arena.set_first_child(value_node, first_node)
+
+		return value_node
 	}
 
 	// Helper to check if token is all whitespace (inline for hot paths)
@@ -293,8 +291,10 @@ export class ValueParser {
 			}
 		}
 
-		// Parse function arguments (everything until matching ')')
-		let args: number[] = []
+		// Parse function arguments (everything until matching ')'), chained as siblings
+		// without an intermediate array (single-argument calls like var(--x) are common)
+		let first_arg = 0
+		let last_arg = 0
 		let paren_depth = 1
 		let func_end = end
 		let content_start = end // Position after function name and '('
@@ -325,7 +325,12 @@ export class ValueParser {
 			// Parse argument node
 			let arg_node = this.parse_value_node()
 			if (arg_node !== null) {
-				args.push(arg_node)
+				if (first_arg === 0) {
+					first_arg = arg_node
+				} else {
+					this.arena.set_next_sibling(last_arg, arg_node)
+				}
+				last_arg = arg_node
 			}
 		}
 
@@ -337,7 +342,9 @@ export class ValueParser {
 		this.arena.set_value_length(node, content_end - content_start)
 
 		// Link arguments as children
-		this.arena.append_children(node, args)
+		if (first_arg !== 0) {
+			this.arena.set_first_child(node, first_arg)
+		}
 
 		return node
 	}
@@ -352,8 +359,10 @@ export class ValueParser {
 			this.lexer.token_column,
 		)
 
-		// Parse parenthesized content (everything until matching ')')
-		let children: number[] = []
+		// Parse parenthesized content (everything until matching ')'), chained as siblings
+		// without an intermediate array
+		let first_child = 0
+		let last_child = 0
 		let paren_depth = 1
 		let paren_end = end
 
@@ -383,7 +392,12 @@ export class ValueParser {
 			// because parse_value_node() will recursively handle them
 			let child_node = this.parse_value_node()
 			if (child_node !== null) {
-				children.push(child_node)
+				if (first_child === 0) {
+					first_child = child_node
+				} else {
+					this.arena.set_next_sibling(last_child, child_node)
+				}
+				last_child = child_node
 			}
 		}
 
@@ -391,7 +405,9 @@ export class ValueParser {
 		this.arena.set_length(node, paren_end - start)
 
 		// Link children as siblings
-		this.arena.append_children(node, children)
+		if (first_child !== 0) {
+			this.arena.set_first_child(node, first_child)
+		}
 
 		return node
 	}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -132,20 +132,28 @@ export class Parser {
 		// Create the root stylesheet node
 		let stylesheet = this.arena.create_node(STYLESHEET, 0, this.source.length, 1, 1)
 
-		// Parse all rules at the top level
-		let rules: number[] = []
+		// Parse all rules at the top level, chained as siblings without an intermediate array
+		let first_rule = 0
+		let last_rule = 0
 		while (!this.is_eof()) {
 			let rule = this.parse_rule()
 			if (rule === null) {
 				// Skip unknown tokens
 				this.next_token()
 			} else {
-				rules.push(rule)
+				if (first_rule === 0) {
+					first_rule = rule
+				} else {
+					this.arena.set_next_sibling(last_rule, rule)
+				}
+				last_rule = rule
 			}
 		}
 
 		// Link all rules as children
-		this.arena.append_children(stylesheet, rules)
+		if (first_rule !== 0) {
+			this.arena.set_first_child(stylesheet, first_rule)
+		}
 
 		// Release wasted pre-allocated capacity now that node count is final
 		this.arena.trim()
@@ -210,38 +218,44 @@ export class Parser {
 			block_column,
 		)
 
-		// Parse declarations block (and nested rules for CSS Nesting)
-		let block_children: number[] = []
+		// Parse declarations block (and nested rules for CSS Nesting), chained as siblings
+		// without an intermediate array
+		let first_child = 0
+		let last_child = 0
 		while (!this.is_eof()) {
 			let token_type = this.peek_type()
 			if (token_type === TOKEN_RIGHT_BRACE) break
 
+			let child: number | null = null
+
 			// Check for nested at-rule
 			if (token_type === TOKEN_AT_KEYWORD) {
-				let nested_at_rule = this.parse_atrule()
-				if (nested_at_rule === null) {
+				child = this.parse_atrule()
+				if (child === null) {
 					this.next_token()
-				} else {
-					block_children.push(nested_at_rule)
 				}
-				continue
-			}
-
-			// Try to parse as declaration first
-			let declaration = this.parse_declaration()
-			if (declaration !== null) {
-				this.arena.set_flag(style_rule, FLAG_HAS_DECLARATIONS)
-				block_children.push(declaration)
-				continue
-			}
-
-			// If not a declaration, try parsing as nested style rule
-			let nested_rule = this.parse_style_rule()
-			if (nested_rule === null) {
-				// Skip unknown tokens
-				this.next_token()
 			} else {
-				block_children.push(nested_rule)
+				// Try to parse as declaration first
+				child = this.parse_declaration()
+				if (child === null) {
+					// If not a declaration, try parsing as nested style rule
+					child = this.parse_style_rule()
+					if (child === null) {
+						// Skip unknown tokens
+						this.next_token()
+					}
+				} else {
+					this.arena.set_flag(style_rule, FLAG_HAS_DECLARATIONS)
+				}
+			}
+
+			if (child !== null) {
+				if (first_child === 0) {
+					first_child = child
+				} else {
+					this.arena.set_next_sibling(last_child, child)
+				}
+				last_child = child
 			}
 		}
 
@@ -256,7 +270,9 @@ export class Parser {
 
 		// Set block length and link its children
 		this.arena.set_length(block_node, block_end - block_start)
-		this.arena.append_children(block_node, block_children)
+		if (first_child !== 0) {
+			this.arena.set_first_child(block_node, first_child)
+		}
 
 		// Set the rule's length and link children (selector + block)
 		this.arena.set_length(style_rule, rule_end - rule_start)
@@ -474,7 +490,9 @@ export class Parser {
 
 			// Determine what to parse inside the block based on the at-rule name
 			let has_declarations = this.atrule_has_declarations(at_rule_name)
-			let block_children: number[] = []
+			// Chain block children as siblings without an intermediate array
+			let first_child = 0
+			let last_child = 0
 
 			if (has_declarations) {
 				// Parse declarations only (like @font-face, @page)
@@ -486,7 +504,12 @@ export class Parser {
 					if (declaration === null) {
 						this.next_token()
 					} else {
-						block_children.push(declaration)
+						if (first_child === 0) {
+							first_child = declaration
+						} else {
+							this.arena.set_next_sibling(last_child, declaration)
+						}
+						last_child = declaration
 					}
 				}
 			} else {
@@ -495,31 +518,34 @@ export class Parser {
 					let token_type = this.peek_type()
 					if (token_type === TOKEN_RIGHT_BRACE) break
 
+					let child: number | null = null
+
 					// Check for nested at-rule
 					if (token_type === TOKEN_AT_KEYWORD) {
-						let nested_at_rule = this.parse_atrule()
-						if (nested_at_rule === null) {
+						child = this.parse_atrule()
+						if (child === null) {
 							this.next_token()
-						} else {
-							block_children.push(nested_at_rule)
 						}
-						continue
-					}
-
-					// Try to parse as declaration first
-					let declaration = this.parse_declaration()
-					if (declaration !== null) {
-						block_children.push(declaration)
-						continue
-					}
-
-					// If not a declaration, try parsing as nested style rule
-					let nested_rule = this.parse_style_rule()
-					if (nested_rule === null) {
-						// Skip unknown tokens
-						this.next_token()
 					} else {
-						block_children.push(nested_rule)
+						// Try to parse as declaration first
+						child = this.parse_declaration()
+						if (child === null) {
+							// If not a declaration, try parsing as nested style rule
+							child = this.parse_style_rule()
+							if (child === null) {
+								// Skip unknown tokens
+								this.next_token()
+							}
+						}
+					}
+
+					if (child !== null) {
+						if (first_child === 0) {
+							first_child = child
+						} else {
+							this.arena.set_next_sibling(last_child, child)
+						}
+						last_child = child
 					}
 				}
 			}
@@ -538,7 +564,9 @@ export class Parser {
 			}
 
 			// Link block children
-			this.arena.append_children(block_node, block_children)
+			if (first_child !== 0) {
+				this.arena.set_first_child(block_node, first_child)
+			}
 
 			// Set at-rule length and link children (prelude_wrapper?, block)
 			this.arena.set_length(at_rule, last_end - at_rule_start)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -260,12 +260,12 @@ export class Parser {
 
 		// Set the rule's length and link children (selector + block)
 		this.arena.set_length(style_rule, rule_end - rule_start)
-		let style_rule_children: number[] = []
-		if (selector !== null) {
-			style_rule_children.push(selector)
+		if (selector === null) {
+			this.arena.set_first_child(style_rule, block_node)
+		} else {
+			this.arena.set_first_child(style_rule, selector)
+			this.arena.set_next_sibling(selector, block_node)
 		}
-		style_rule_children.push(block_node)
-		this.arena.append_children(style_rule, style_rule_children)
 
 		return style_rule
 	}
@@ -540,16 +540,14 @@ export class Parser {
 			// Link block children
 			this.arena.append_children(block_node, block_children)
 
-			// Build at-rule children: [prelude_wrapper?, block]
-			let at_rule_children: number[] = []
-			if (prelude_wrapper !== null) {
-				at_rule_children.push(prelude_wrapper)
-			}
-			at_rule_children.push(block_node)
-
-			// Set at-rule length and link children
+			// Set at-rule length and link children (prelude_wrapper?, block)
 			this.arena.set_length(at_rule, last_end - at_rule_start)
-			this.arena.append_children(at_rule, at_rule_children)
+			if (prelude_wrapper === null) {
+				this.arena.set_first_child(at_rule, block_node)
+			} else {
+				this.arena.set_first_child(at_rule, prelude_wrapper)
+				this.arena.set_next_sibling(prelude_wrapper, block_node)
+			}
 		} else {
 			if (this.peek_type() === TOKEN_SEMICOLON) {
 				// Statement at-rule (like @import, @namespace)
@@ -559,7 +557,7 @@ export class Parser {
 			// else: no block or semicolon (error recovery)
 			this.arena.set_length(at_rule, last_end - at_rule_start)
 			if (prelude_wrapper !== null) {
-				this.arena.append_children(at_rule, [prelude_wrapper])
+				this.arena.set_first_child(at_rule, prelude_wrapper)
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR refactors the CSS parser to eliminate intermediate array allocations by chaining parsed nodes as siblings directly in the arena. This optimization targets the common case where most CSS constructs (media queries, container queries, selector lists, values, declaration blocks, etc.) contain a single element, avoiding unnecessary array allocations and push operations.

## Key Changes

- **Sibling chaining pattern**: Replaced `let nodes: number[] = []` followed by `nodes.push(node)` with a pattern that tracks `first_node`/`last_node` (or `first_child`/`last_child`), linking them via `arena.set_next_sibling()`. This avoids allocating arrays regardless of how many items end up in the chain — not just the single-element case.

- **Arena helper method**: Added `get_last_sibling(node_index)` to walk a sibling chain and find its tail, enabling efficient appending to chains built incrementally (used when a chain being appended may itself already be a multi-node chain, e.g. a compound selector's parts).

- **Parser updates across multiple files**:
  - `parse-atrule-prelude.ts`: Media queries, container queries, feature values, and range features now chain components as siblings; single-child `append_children(x, [y])` sites replaced with `set_first_child`.
  - `parse-value.ts`: Value tokens and function/parenthesis arguments chain as siblings instead of arrays — this is the hottest path in the parser, since it runs once per declaration.
  - `parse-selector.ts`: Selector lists, complex selectors, and compound selector parts chain as siblings. Also removed a dead sibling-chain scan in `parse_selector_list` whose result was never used.
  - `parse.ts`: Top-level stylesheet rules, style-rule block children, and at-rule block children are now built as chains incrementally instead of `number[]` + `append_children`, with the selector/block and prelude/block pairs linked directly via `set_first_child()`/`set_next_sibling()`.
  - `parse-declaration.ts`: Single child nodes (the declaration's VALUE/RAW node) use `set_first_child()` instead of `append_children(decl, [node])`.

- **Internal-only return type changes**: Private helpers like `parse_feature_value()` now return `number` (first node index, `0` = empty) instead of `number[]`. No public API signatures changed — `AtRulePreludeParser.parse_prelude()` and the exported `parse_atrule_prelude()` still return `number[]`/`AnyNode[]` as before.

## Implementation Details

- The optimization maintains the same AST structure — nodes are still chained as siblings, just without the intermediate array wrapper.
- When appending a chain to an existing chain, `arena.get_last_sibling()` is used to find the insertion point.
- Empty cases are represented by `0` instead of empty arrays, simplifying null checks.
- Comments document the rationale for each optimization, noting that single-element cases are the common path.

## Benchmarks

Measured with `pnpm run benchmark` (tinybench, `--expose-gc`), comparing this branch against `main` (commit `c428a0b`):

**Parse throughput (ops/sec, higher is better)**

| File | Size | Before | After | Change |
| --- | --- | --- | --- | --- |
| Large | 3 KB | 8510 | 9588 | +12.7% |
| Bootstrap | 274 KB | 108 | 117 | +8.3% |
| Tailwind | 3557 KB | 7 | 8 | +14.3% |

**Parse+Walk memory (lower is better)**

| File | Size | Before | After | Change |
| --- | --- | --- | --- | --- |
| Large | 3 KB | 0.2 MB | 0.1 MB | -50% |
| Bootstrap | 274 KB | 12.6 MB | 7.9 MB | -37.3% |
| Tailwind | 3557 KB | 48.7 MB | 40.3 MB | -17.3% |

No behavioral change — all 1365 existing tests pass unmodified, `tsc --noEmit` and lint are clean.

https://claude.ai/code/session_01Dr6qmDsm5A5SyccNES4ixs